### PR TITLE
chore: layotto start without `-c` or `--config`

### DIFF
--- a/configs/config.json
+++ b/configs/config.json
@@ -57,8 +57,9 @@
                       },
                       "secret_store": {
                         "secret_demo": {
-                          "type": "local.env",
+                          "type": "local.file",
                           "metadata": {
+                            "secretsFile": "secret_local_file.json"
                           }
                         }
                       },

--- a/docs/en/operation/README.md
+++ b/docs/en/operation/README.md
@@ -22,7 +22,7 @@ You can run Layotto using the official Docker images.Currently include:
 It does not contain a `config.json` configuration file in the image, you can mount your own configuration file into the `/runtime/configs/` directory of the image. For example.
 
 ```shell
-docker run -v "$(pwd)/configs/config.json:/runtime/configs/config.json" -d  -p 34904:34904 --name layotto layotto/layotto start
+docker run -v "$(pwd)/configs/:/runtime/configs/" -d  -p 34904:34904 --name layotto layotto/layotto start
 ```
 
 Of course, you can also run Layotto and other systems (such as Redis) at the same time via docker-compose. Refer to the [Quick start](en/start/state/start?id=step-1-deploy-redis-and-layotto)

--- a/docs/en/start/secret/start.md
+++ b/docs/en/start/secret/start.md
@@ -1,4 +1,4 @@
-# use Secret API to obtain secret
+# use Secret API to query secrets
 ## What is Secret API
 The secret API is used to obtain secret from file, env, k8s, etc
 

--- a/docs/zh/operation/README.md
+++ b/docs/zh/operation/README.md
@@ -17,7 +17,15 @@ Layotto 提供了官方 Docker 镜像，包括：
 镜像内不包含 `config.json` 配置文件，您可以将自己的配置文件挂载进镜像的`/runtime/configs/config.json`目录, 然后启动镜像。例如：
 
 ```shell
-docker run -v "$(pwd)/configs/config.json:/runtime/configs/config.json" -d  -p 34904:34904 --name layotto layotto/layotto start
+docker run -v "$(pwd)/configs/:/runtime/configs/" -d  -p 34904:34904 --name layotto layotto/layotto start
+```
+
+可以运行 demo 测试效果:
+
+```shell
+ cd demo/sequencer/common/
+ go build -o client
+ ./client -s "sequencer_demo"
 ```
 
 您也可以通过 docker-compose 同时启动 Layotto 和 其他系统（比如 Redis)，参考[快速开始](zh/start/state/start?id=step-1-%e5%90%af%e5%8a%a8-redis-%e5%92%8c-layotto)

--- a/etc/script/test-quickstart.sh
+++ b/etc/script/test-quickstart.sh
@@ -39,6 +39,7 @@ quickstarts_in_default="docs/en/start/configuration/start.md
   docs/zh/start/wasm/start.md
   docs/en/start/secret/start.md
   docs/zh/start/secret/start.md
+  docs/zh/operation/README.md
 "
 
 # In advance mod, we test these docs with golang 1.17


### PR DESCRIPTION
Signed-off-by: seeflood <zhou.qunli@foxmail.com>

<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:
A demo will use `./layotto start` without `-c` or `--config`
Used as test cases for https://github.com/mosn/layotto/pull/669
Will test cases including:
- `./layotto start`  without `-c` or `--config` flags. 
-  `case 2` in https://github.com/mosn/layotto/issues/631 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```